### PR TITLE
Correct tones for 不 and 一 based on context

### DIFF
--- a/spec/spec.js
+++ b/spec/spec.js
@@ -46,6 +46,8 @@ describe("Pinyinify", () => {
         expect("我现在富得能买我想要的任何东西。").becomes("wǒ xiàn​zài fù de néng mǎi wǒ xiǎng​yào de rèn​hé dōng​xi.");
         expect("我们就得这么做。").becomes("wǒ​men jiù děi zhè​me zuò.");
         expect("你现在得把门打开。正在动手。").becomes("nǐ xiàn​zài děi bǎ​mén dǎ​kāi. zhèng​zài dòng​shǒu.");
+        expect("听着，我得先见见这人").becomes("tīng zhe, wǒ děi xiān jiàn jiàn zhè rén");
+        expect("我得了什么病？").becomes("wǒ dé le shén​me bìng?");
         // 还
         expect("我有钱了就还你。").becomes("wǒ yǒu​qián le jiù huán nǐ.");
         expect("我还给你。").becomes("wǒ huán​gěi nǐ.");
@@ -54,11 +56,14 @@ describe("Pinyinify", () => {
         expect("他还会把钱还律师吗？").becomes("tā hái huì bǎ qián huán lǜ​shī ma?");
         expect("好吧，我至少还有些朋友。").becomes("hǎo ba, wǒ zhì​shǎo hái yǒu​xiē péng​you.");
         expect("你还爱我吗？").becomes("nǐ hái ài wǒ ma?");
+        expect("把我小孩还来！").becomes("bǎ wǒ xiǎo​hái huán lái!");
         // 只
         expect("他是一只鸟。").becomes("tā shì yì zhī niǎo.");
         // 长
         expect("她长着一张圆脸和一双明亮的眼睛。").becomes("tā zhǎng zhe yì zhāng yuán liǎn hé yì shuāng míng​liàng de yǎn​jing.");
         expect("不是他干的，警长。").becomes("bù​shì tā gàn de, jǐng zhǎng.");
+        expect("你的头发太长了。").becomes("nǐ de tóu​fa tài cháng le.");
+        expect("我后背上长了个东西。").becomes("wǒ hòu bèi shàng zhǎng le gè dōng​xi.");
         // 系
         expect("这女孩要我给她把衣服从后面系上。").becomes("zhè nǚ​hái yào wǒ gěi tā bǎ yī​fu cóng hòu​miàn jì shàng.");
         expect("一个人的后面有一个系着领带的男人走在道路上").becomes("yí gè rén de hòu​miàn yǒu yí gè jì zhe lǐng​dài de nán​rén zǒu zài dào​lù shàng");
@@ -72,6 +77,9 @@ describe("Pinyinify", () => {
 
         // 弹
         expect("一个双手弹着吉他的男人在舞台上表演").becomes("yí gè shuāng​shǒu tán zhe jí​tā de nán​rén zài wǔ​tái shàng biǎo​yǎn");
+
+
+
 
         expect("行了吗？").becomes("xíng le ma?");
         expect("人要是行干一行行一行。").becomes("rén yào​shi xíng gàn yì háng xíng yì háng.");
@@ -154,5 +162,10 @@ describe("Traditionalize", () => {
     });
     it("chooses right ambiguous character", () => {
         expect(traditionalize(`你对那个女的干了什么？`)).toEqual("你對那個女的幹了什麼？");
+        // 干
+        expect(traditionalize("你没把面包包好，它变干了。")).toEqual("你沒把麵包包好，它變乾了。");
+        // 面
+        expect(traditionalize("房间里有一个坐着的男人看着一个在吃面的男人")).toEqual("房間裡有一個坐著的男人看著一個在吃麵的男人");
+        expect(traditionalize("我吃面。")).toEqual("我吃麵。");
     });
 });

--- a/spec/spec.js
+++ b/spec/spec.js
@@ -26,13 +26,13 @@ describe("Pinyinify", () => {
 
     it("selects the correct pronunciation for 多音字", () => {
         expect("我受不了了").becomes("wǒ shòu​bù​liǎo le");
-        expect("我觉得睡觉是很重要的。我睡了一个好觉有很好的感觉。").becomes("wǒ jué​de shuì​jiào shì hěn zhòng​yào de. wǒ shuì le yī gè hǎo jiào yǒu hěn hǎo de gǎn​jué.");
+        expect("我觉得睡觉是很重要的。我睡了一个好觉有很好的感觉。").becomes("wǒ jué​de shuì​jiào shì hěn zhòng​yào de. wǒ shuì le yí gè hǎo jiào yǒu hěn hǎo de gǎn​jué.");
         expect("你看她干吗？她是你的女朋友吗？").becomes("nǐ kàn tā gàn​má? tā shì nǐ de nǚ​péng​you ma?");
         expect("他给我发了个短信：“我长大的时候我的头发很长。但是现在我喜欢理发。”").becomes("tā gěi wǒ fā le gè duǎn​xìn: ``wǒ zhǎng​dà de shí​hou wǒ de tóu​fa hěn cháng. dàn​shì xiàn​zài wǒ xǐ​huan lǐ​fà.\"");
         expect("我们都想去首都玩。").becomes("wǒ​men dōu xiǎng qù shǒu​dū wán.");
-        expect("不要应该睡觉时不睡觉。").becomes("bù​yào yīng​gāi shuì​jiào shí bù shuì​jiào.");
+        expect("不要应该睡觉时不睡觉。").becomes("bù​yào yīng​gāi shuì​jiào shí bú shuì​jiào.");
         expect("你找到什么吃的了么？").becomes("nǐ zhǎo​dào shén​me chī de le me?");
-        expect("一个穿着神色的裤子的男人坐在火车上。").becomes("yī gè chuān zhe shén​sè de kù​zi de nán​rén zuò zài huǒ​chē shàng.");
+        expect("一个穿着神色的裤子的男人坐在火车上。").becomes("yí gè chuān zhe shén​sè de kù​zi de nán​rén zuò zài huǒ​chē shàng.");
         expect("东西").becomes("dōng​xi");
         // 得
         expect("我们得现在就谈吗？").becomes("wǒ​men děi xiàn​zài jiù tán ma?");
@@ -46,8 +46,6 @@ describe("Pinyinify", () => {
         expect("我现在富得能买我想要的任何东西。").becomes("wǒ xiàn​zài fù de néng mǎi wǒ xiǎng​yào de rèn​hé dōng​xi.");
         expect("我们就得这么做。").becomes("wǒ​men jiù děi zhè​me zuò.");
         expect("你现在得把门打开。正在动手。").becomes("nǐ xiàn​zài děi bǎ​mén dǎ​kāi. zhèng​zài dòng​shǒu.");
-        expect("听着，我得先见见这人").becomes("tīng zhe, wǒ děi xiān jiàn jiàn zhè rén");
-        expect("我得了什么病？").becomes("wǒ dé le shén​me bìng?");
         // 还
         expect("我有钱了就还你。").becomes("wǒ yǒu​qián le jiù huán nǐ.");
         expect("我还给你。").becomes("wǒ huán​gěi nǐ.");
@@ -56,17 +54,14 @@ describe("Pinyinify", () => {
         expect("他还会把钱还律师吗？").becomes("tā hái huì bǎ qián huán lǜ​shī ma?");
         expect("好吧，我至少还有些朋友。").becomes("hǎo ba, wǒ zhì​shǎo hái yǒu​xiē péng​you.");
         expect("你还爱我吗？").becomes("nǐ hái ài wǒ ma?");
-        expect("把我小孩还来！").becomes("bǎ wǒ xiǎo​hái huán lái!");
         // 只
-        expect("他是一只鸟。").becomes("tā shì yī zhī niǎo.");
+        expect("他是一只鸟。").becomes("tā shì yì zhī niǎo.");
         // 长
-        expect("她长着一张圆脸和一双明亮的眼睛。").becomes("tā zhǎng zhe yī zhāng yuán liǎn hé yī shuāng míng​liàng de yǎn​jing.");
+        expect("她长着一张圆脸和一双明亮的眼睛。").becomes("tā zhǎng zhe yì zhāng yuán liǎn hé yì shuāng míng​liàng de yǎn​jing.");
         expect("不是他干的，警长。").becomes("bù​shì tā gàn de, jǐng zhǎng.");
-        expect("你的头发太长了。").becomes("nǐ de tóu​fa tài cháng le.");
-        expect("我后背上长了个东西。").becomes("wǒ hòu bèi shàng zhǎng le gè dōng​xi.");
         // 系
         expect("这女孩要我给她把衣服从后面系上。").becomes("zhè nǚ​hái yào wǒ gěi tā bǎ yī​fu cóng hòu​miàn jì shàng.");
-        expect("一个人的后面有一个系着领带的男人走在道路上").becomes("yī gè rén de hòu​miàn yǒu yī gè jì zhe lǐng​dài de nán​rén zǒu zài dào​lù shàng");
+        expect("一个人的后面有一个系着领带的男人走在道路上").becomes("yí gè rén de hòu​miàn yǒu yí gè jì zhe lǐng​dài de nán​rén zǒu zài dào​lù shàng");
 
         // 地
         expect("我说过我不会卖那块地的！").becomes("wǒ shuō guò wǒ bù​huì mài nà kuài dì de!");
@@ -76,13 +71,10 @@ describe("Pinyinify", () => {
         expect("我重入了房间并且去了工作。").becomes("wǒ chóng rù le fáng​jiān bìng​qiě qù le gōng​zuò.");
 
         // 弹
-        expect("一个双手弹着吉他的男人在舞台上表演").becomes("yī gè shuāng​shǒu tán zhe jí​tā de nán​rén zài wǔ​tái shàng biǎo​yǎn");
-
-
-
+        expect("一个双手弹着吉他的男人在舞台上表演").becomes("yí gè shuāng​shǒu tán zhe jí​tā de nán​rén zài wǔ​tái shàng biǎo​yǎn");
 
         expect("行了吗？").becomes("xíng le ma?");
-        expect("人要是行干一行行一行。").becomes("rén yào​shi xíng gàn yī háng xíng yī háng.");
+        expect("人要是行干一行行一行。").becomes("rén yào​shi xíng gàn yì háng xíng yì háng.");
         expect("几行代码？两行代码。行还是不行？行！").becomes("jǐ háng dài​mǎ? liǎng háng dài​mǎ. xíng hái​shi bù​xíng? xíng!");
 
         expect("结果").becomes("jié​guǒ");
@@ -162,10 +154,5 @@ describe("Traditionalize", () => {
     });
     it("chooses right ambiguous character", () => {
         expect(traditionalize(`你对那个女的干了什么？`)).toEqual("你對那個女的幹了什麼？");
-        // 干
-        expect(traditionalize("你没把面包包好，它变干了。")).toEqual("你沒把麵包包好，它變乾了。");
-        // 面
-        expect(traditionalize("房间里有一个坐着的男人看着一个在吃面的男人")).toEqual("房間裡有一個坐著的男人看著一個在吃麵的男人");
-        expect(traditionalize("我吃面。")).toEqual("我吃麵。");
     });
 });

--- a/src/pinyinify.js
+++ b/src/pinyinify.js
@@ -5,6 +5,14 @@ let segment = require("./segment"),
     tag = require("./tag"),
     { isCharacterText } = require("./util");
 
+const tones = [
+    ['ā','ē','ī','ō','ū','ǖ','Ā','Ē','Ī','Ō','Ū','Ǖ'],
+    ['á','é','í','ó','ú','ǘ','Á','É','Í','Ó','Ú','Ǘ'],
+    ['ǎ','ě','ǐ','ǒ','ǔ','ǚ','Ǎ','Ě','Ǐ','Ǒ','Ǔ','Ǚ'],
+    ['à','è','ì','ò','ù','ǜ','À','È','Ì','Ò','Ù','Ǜ'],
+    ['a','e','i','o','u','ü','A','E','I','O','U','Ü']
+]; //Use tones[tone - 1] to get all possible characters with that tone
+
 function pinyinify(text, isDetailed) {
     let segments = segment(text);
     let pinyinSegments = [];
@@ -159,6 +167,19 @@ function decideAmbiguousChar(char, cuts, cutIndex) {
                 if (afterTag[0] === "v") return "chóng";
             }
             break;
+        case "不":
+            if (afterText.length > 0) {
+                const nextTone = getTone(afterText[0].charAt(0));
+                if (nextTone === 4) return "bú";
+            }
+            break;
+        case "一":
+            if (afterText.length > 0) {
+                const nextTone = getTone(afterText[0].charAt(0));
+                if (nextTone === 1 || nextTone == 2 || nextTone == 3) return "yì";
+                else if (nextTone == 4) return "yí";
+            }
+            break;
     }
 }
 
@@ -176,7 +197,16 @@ function shouldPutSpaceBetween(word1, word2) {
     if (isCharacterText(word1) && punctuationPattern.test(word2)) return false;
     if (isCharacterText(word1) !== isCharacterText(word2)) return true;
     return false;
+}
 
+function getTone(char) {
+    if(typeof pinyinDict[char] === 'undefined') return 0;
+
+    const pinyinChars = [...pinyinDict[char]]; //Getting and destructuring the pinyin string
+    for (i = 0; i < 4; i++) { //Going through the four tones and checking if there is a match
+        if (tones[i].some(c => pinyinChars.includes(c))) return i + 1;
+    }
+    return 5;
 }
 
 module.exports = pinyinify;


### PR DESCRIPTION
不 is usually bù, but if the next character has the fourth tone it will become bú. Example: wǒ bú qù nǐ, wǒ bù xǐ​huan nǐ
一 is usually yī, but if the next character has the first, second or third tone it will become yì. If the next character has the fourth tone, it will become yí. Example: yī. yí gè rén. yì běn shū